### PR TITLE
🐛 fix(afloatPalletApi.js): remove redundant afloatPalletApi prefix fr…

### DIFF
--- a/src/model/polkadot-pallets/afloatPalletApi.js
+++ b/src/model/polkadot-pallets/afloatPalletApi.js
@@ -10,7 +10,7 @@ class AfloatPalletApi extends BasePolkadot {
   }
 
   updateUserInfo ({ address, args }) {
-    return this.afloatPalletApi.callTx({
+    return this.callTx({
       extrinsicName: 'updateUserInfo',
       signer: this._signer,
       params: [address, args]


### PR DESCRIPTION
…om callTx method

The afloatPalletApi prefix is redundant as the callTx method is already defined within the AfloatPalletApi class. Removing the prefix improves code readability and consistency.