### PR TITLE
🔀 refactor(afloatApi.js, gatedMarketplaceApi.js): add subscription su…

### DIFF
--- a/src/model/polkadot-pallets/afloatApi.js
+++ b/src/model/polkadot-pallets/afloatApi.js
@@ -240,8 +240,8 @@ class AfloatApi extends BasePolkadot {
    * @param {String} collectionId The ID of the collection
    * @return {}
    */
-  async getOffersByCollection ({ collectionId }) {
-    const offers = await this.gatedMarketplaceApi.getAllOffersByCollection({ collectionId })
+  async getOffersByCollection ({ collectionId }, subTrigger) {
+    const offers = await this.gatedMarketplaceApi.getAllOffersByCollection({ collectionId }, subTrigger)
     const promises = []
     const offersFiltered = offers.filter(offer => {
       const { value } = offer || {}
@@ -282,7 +282,7 @@ class AfloatApi extends BasePolkadot {
 
   async getOffersByMarketplace ({ marketplaceId }) {
     let offersIds = await this.gatedMarketplaceApi.exQuery('offersByMarketplace', [marketplaceId])
-    offersIds = offersIds.map(offer => offer.toHuman())
+    offersIds = offersIds?.map(offer => offer.toHuman())
     const offers = await this.getOffersInfo({ offersIds })
     return offers.map((offer, i) => {
       return {
@@ -290,6 +290,10 @@ class AfloatApi extends BasePolkadot {
         offerId: offersIds[i]
       }
     })
+  }
+
+  async subscriptionOffersByMarketplace ({ marketplaceId }, subTrigger) {
+    return this.gatedMarketplaceApi.exQuery('offersByMarketplace', [marketplaceId], subTrigger)
   }
 
   /**

--- a/src/model/polkadot-pallets/gatedMarketplaceApi.js
+++ b/src/model/polkadot-pallets/gatedMarketplaceApi.js
@@ -62,8 +62,8 @@ class GatedMarketplaceApi extends BasePolkadot {
    * @param {String} collectionId The id of the collection
    * @returns {Array}
    */
-  async getAllOffersByCollection ({ collectionId }) {
-    const offers = await this.exEntriesQuery('offersByItem', [collectionId])
+  async getAllOffersByCollection ({ collectionId }, subTrigger) {
+    const offers = await this.exEntriesQuery('offersByItem', [collectionId], subTrigger)
     return this.mapEntries(offers)
   }
 


### PR DESCRIPTION
…pport to get offers by collection and get all offers by collection methods

The `getOffersByCollection` and `getAllOffersByCollection` methods in `afloatApi.js` and `gatedMarketplaceApi.js` now accept a `subTrigger` parameter to support subscriptions. This allows the methods to be used with a subscription-based approach, which is more efficient than polling.