### PR TITLE
Admin extrinsics

### DIFF
--- a/src/model/polkadot-pallets/afloatApi.js
+++ b/src/model/polkadot-pallets/afloatApi.js
@@ -384,6 +384,22 @@ class AfloatApi extends BasePolkadot {
     })
   }
 
+  async setAfloatBalance ({ address, amount }) {
+    return this.afloatPalletApi.callTx({
+      extrinsicName: 'setAfloatBalance',
+      signer: this._signer,
+      params: [address, amount]
+    })
+  }
+
+  async addAfloatAdmin ({ address }) {
+    return this.afloatPalletApi.callTx({
+      extrinsicName: 'addAfloatAdmin',
+      signer: this._signer,
+      params: [address]
+    })
+  }
+
   /**
    * @name getOfferInfo
    * @param {String} OfferId The if of the offer to retrieve


### PR DESCRIPTION
## Description 📝

This PR introduces two new features to the `afloatApi.js` file:

1. 🚀 `setAfloatBalance` Method: This method is added to enable the setting of the balance for a specific address in the afloat pallet. It accepts two parameters, `address` and `amount`, and triggers the `setAfloatBalance` extrinsic.

2. 🚀 `addAfloatAdmin` Method: This method is introduced to facilitate the addition of an address as an admin in the afloat pallet. It takes a single parameter, `address`, and invokes the `addAfloatAdmin` extrinsic.